### PR TITLE
refactor(translate): use Environment.get()

### DIFF
--- a/main-server/src/config/env/env.validation.spec.ts
+++ b/main-server/src/config/env/env.validation.spec.ts
@@ -31,6 +31,8 @@ describe('env validation, Environment class init test', () => {
       MONGO_URI: 'mongodb://mgdb:27017/aigoo',
       // CRYPTO_SECRET: 'mock',
       AZURE_STORAGE_CONNECTION_STRING: 'mock',
+      NAVER_OCR_SECRET: '',
+      NAVER_OCR_URL: '',
     };
 
     //transform mock to EnvConfig, vlalidate config, init Environment class

--- a/main-server/src/modules/translate/translate.controller.ts
+++ b/main-server/src/modules/translate/translate.controller.ts
@@ -13,16 +13,6 @@ export class TranslateController {
   @Get('test')
   @ApiResponse({ description: '번역된 텍스트' })
   async getTestTranslate(): ReturnType<typeof TranslateService.prototype.run> {
-    // const exampleText = [
-    //   "Please, don't see.",
-    //   'Just boy caught up in dreams and fantasie.',
-    //   'please, see me.',
-    //   'reaching out for someone I can see.',
-    //   "Take my hand, let's see where we wake up tomorrow.",
-    //   'Best laid plans sometimes are just a one night stand.',
-    // ];
-    // return this.translateService.translate(exampleText);
-
     const testPngUrl =
       'https://aigooback.blob.core.windows.net/test/demo-img.jpg';
     return await this.translateService.run(testPngUrl);

--- a/main-server/src/modules/translate/translate.service.ts
+++ b/main-server/src/modules/translate/translate.service.ts
@@ -6,6 +6,7 @@ import {
   HarmCategory,
   SafetySetting,
 } from './translate.definition';
+import { Environment } from 'src/config/env/env.service';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const GlobalSafetySettings: SafetySetting[] = [
@@ -62,26 +63,32 @@ Respond only with the converted result, without any explanation of the content.
 export class TranslateService {
   private logger = new Logger(TranslateService.name);
 
+  // 이미지 파일 URL을 받아, OCR로 텍스트를 추출하고, 오타 교정 및 번역을 실행합니다.
   async run(uploaded: string): Promise<{
     originText: string[];
     translatedText: string[];
   }> {
+    // 1. 이미지 파일이 저장된 URL 처리
     const fileUrl = new URL(uploaded);
     const ext = fileUrl.pathname.split('.').pop();
 
+    // 1-1. 확장자 체크: JPG 또는 PDF만 지원되게 함
     if (ext !== 'jpg' && ext !== 'pdf') {
       this.logger.error(`Invalid file type. ext: ${ext}`);
       throw new Error('Invalid file type. allowed: jpg, pdf');
     }
 
+    // 2. OCR로 스캔된 텍스트를 가져옴
     const pred = await this.getTextFromFile(fileUrl, ext);
 
-    const fixed = await this.fixTypo(pred);
-    const translated = await this.translate(fixed);
+    // 3. OCR한 문장 배열을 오타 수정, 번역
+    const typofixed = await this.fixTypo(pred);
+    const translated = await this.translate(typofixed);
 
-    return { originText: fixed, translatedText: translated };
+    return { originText: typofixed, translatedText: translated };
   }
 
+  // LLM을 사용해 문장 배열에 대한 번역을 실행합니다.
   async translate(sentence: string[]): Promise<string[]> {
     const model = new ChatGoogleGenerativeAI({
       model: 'gemini-1.5-flash',
@@ -89,6 +96,7 @@ export class TranslateService {
       safetySettings: GlobalSafetySettings,
     });
 
+    // 번역 모델에 문장 배열을 전달
     const pred = await model.invoke([
       ['system', SystemPrompts.translate],
       ['user', sentence.join('\n')],
@@ -101,6 +109,7 @@ export class TranslateService {
       .map((v) => v.trim());
   }
 
+  // LLM을 사용해 문장 배열에 대한 오타 교정을 실행합니다.
   async fixTypo(sentence: string[]): Promise<string[]> {
     const model = new ChatGoogleGenerativeAI({
       model: 'gemini-1.5-flash',
@@ -108,6 +117,7 @@ export class TranslateService {
       safetySettings: GlobalSafetySettings,
     });
 
+    // 오타 교정 모델에 문장 배열을 전달
     const pred = await model.invoke([
       ['system', SystemPrompts.fixtypo],
       ['user', sentence.join('\n')],
@@ -120,12 +130,14 @@ export class TranslateService {
       .map((v) => v.trim());
   }
 
+  // 네이버 OCR API를 사용해 이미지 파일로부터 텍스트를 추출합니다.
   async getTextFromFile(
     uploaded: URL,
     filetype: 'jpg' | 'pdf'
   ): Promise<string[]> {
+    // 1. 네이버 OCR API로 이미지 파일을 텍스트로 변환
     const res = await axios.post(
-      'https://0as2n5rklw.apigw.ntruss.com/custom/v1/31572/1b909269c6d1436ba0a7129edaf4419bd0267e79cb96c14b2620bdf4774e086e/general',
+      Environment.get('NAVER_OCR_URL'),
       {
         images: [
           { format: filetype, name: 'medium', data: null, url: uploaded.href },
@@ -140,7 +152,7 @@ export class TranslateService {
         headers: {
           /* eslint-disable no-alert, @typescript-eslint/naming-convention */
           'Content-Type': 'application/json',
-          'X-OCR-SECRET': process.env.NAVER_OCR_SECRET,
+          'X-OCR-SECRET': Environment.get('NAVER_OCR_SECRET'),
           /* eslint-enable no-alert, @typescript-eslint/naming-convention */
         },
       }
@@ -151,15 +163,20 @@ export class TranslateService {
       boundingPoly: unknown;
       inferText: string;
       inferConfidence: number;
-    }[] = res.data.images[0].fields;
+    }[] = res.data.images[0].fields; // OCR API측 반환 값 기반으로 interface duck-typing
 
     const sentence: string[] = [''];
 
+    // 2. OCR 결과를 문장 단위로 나눔
+    //    문장 끊기는 '.'을 기준으로 함.
     for (const word of preds) {
       const dotIndex = word.inferText.indexOf('.');
       if (dotIndex == -1) {
+        // 2-1. '.'이 없는 경우, 단어를 기존 문장에 그대로 추가 (append)
         sentence[sentence.length - 1] += word.inferText + ' ';
       } else {
+        // 2-2. '.'이 있는 경우, '.'을 기준으로 문장을 나누고,
+        //      새로운 문장을 만들어, 그 다음 단어를 추가 (push)
         sentence[sentence.length - 1] += word.inferText.slice(0, dotIndex + 1);
         sentence.push(word.inferText.slice(dotIndex + 1));
       }


### PR DESCRIPTION
* 네이버 OCR API Config가 없어 환경 변수 파일을 불러오지 못한 문제 수정
* 쓰지 않을 코드 제거 (기존에 주석처리 하였지만 이를 지움.)
* translate Module에서 환경 변수 가져오는 것을 기존 `process.env`에서 `Environment.get()`으로 변경함.