### PR TITLE
feat(translate): Genarate learning materials and transform principal parts (기본형)

### DIFF
--- a/main-server/src/app.module.ts
+++ b/main-server/src/app.module.ts
@@ -56,6 +56,7 @@ export class AppModule implements NestModule {
       .apply(AuthMiddleware)
       .exclude('auth/(.*)')
       .exclude('echo')
+      .exclude('translate/test')
       .forRoutes(
         AppController,
         UserController,

--- a/main-server/src/config/env/env.validation.spec.ts
+++ b/main-server/src/config/env/env.validation.spec.ts
@@ -33,6 +33,7 @@ describe('env validation, Environment class init test', () => {
       AZURE_STORAGE_CONNECTION_STRING: 'mock',
       NAVER_OCR_SECRET: '',
       NAVER_OCR_URL: '',
+      KOREAN_ANALYZE_API_KEY: '',
     };
 
     //transform mock to EnvConfig, vlalidate config, init Environment class

--- a/main-server/src/modules/translate/translate.controller.ts
+++ b/main-server/src/modules/translate/translate.controller.ts
@@ -12,9 +12,14 @@ export class TranslateController {
   })
   @Get('test')
   @ApiResponse({ description: '번역된 텍스트' })
-  async getTestTranslate(): ReturnType<typeof TranslateService.prototype.run> {
-    const testPngUrl =
-      'https://aigooback.blob.core.windows.net/test/demo-img.jpg';
-    return await this.translateService.run(testPngUrl);
+  async getTestTranslate(): ReturnType<
+    typeof TranslateService.prototype.getPrincipalParts
+  > {
+    return await this.translateService.getPrincipalParts([
+      '오른',
+      '갈았다',
+      '나간',
+      '굴러',
+    ]);
   }
 }

--- a/main-server/src/modules/translate/translate.definition.ts
+++ b/main-server/src/modules/translate/translate.definition.ts
@@ -30,3 +30,23 @@ export enum HarmCategory {
   HARM_CATEGORY_HARASSMENT = 'HARM_CATEGORY_HARASSMENT',
   HARM_CATEGORY_DANGEROUS_CONTENT = 'HARM_CATEGORY_DANGEROUS_CONTENT',
 }
+
+export interface LearningSet {
+  // 한글 단어를 영어로 번역한 결과
+  translation: string;
+
+  // 한글 단어에 대한 유의어
+  synonyms: string | null;
+
+  // 한글 단어에 대한 반의어
+  antonyms: string | null;
+
+  // 한글 단어의 발음 기호
+  pronunciation: string;
+
+  // 학습을 위한 응용 문제
+  exercises: string[];
+
+  // 한글 단어에 대한 주의사항
+  caution: string | null;
+}

--- a/main-server/src/modules/translate/translate.service.ts
+++ b/main-server/src/modules/translate/translate.service.ts
@@ -4,9 +4,11 @@ import axios from 'axios';
 import {
   HarmBlockThreshold,
   HarmCategory,
+  LearningSet,
   SafetySetting,
 } from './translate.definition';
 import { Environment } from 'src/config/env/env.service';
+import { parse } from 'yaml';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const GlobalSafetySettings: SafetySetting[] = [
@@ -55,6 +57,56 @@ You will receive as input scanned sentences that have been OCR'd from images.
 Your task is to fix the typos with the intended words, while maintaining the structure of the sentence.
 
 Respond only with the converted result, without any explanation of the content.
+\`\`\`
+`,
+
+  learningSet: `
+\`\`\`txt
+You are a Korean teacher who teaches Korean to English-speaking students.
+
+Given a set of Korean words, you need to provide the following information in "English".
+
+* English translation of the word
+* Synonyms
+* Antonyms
+* Pronunciation symbols
+* Exercises
+* Cautions when using the word
+\`\`\`
+
+The result must be returned in yaml, and must have the following format (the key must not vary):
+
+\`\`\`yaml
+translation: bed
+synonyms: 침상, 잠자리
+antonyms: 의자, 책상
+pronunciation: /t͡ʃim.de/
+exercises: 
+- "Describe your ideal bedroom. (당신의 이상적인 침실에 대해 설명하세요.)"
+- "Write a sentence using '침대' to describe where you sleep. ('침대'를 사용하여 잠자는 장소를 설명하는 문장을 작성하세요.)"
+caution: "'침대' is a common word for 'bed' and is used in most situations."
+\`\`\`
+
+They are separated by commas and return only the response to each item given above without any explanation.
+
+You should also use Markdown code blocks to "separate" the word information.
+
+The following are the given Korean words:
+`,
+  PrincipalParts: `
+\`\`\`txt
+You are a Korean teacher.
+
+Given a Korean word, convert it to its "principal parts (기본형)" form as defined in Korean.
+
+Return only the results in order, with no explanation.
+\`\`\`
+
+\`\`\`txt
+Here's an example:
+
+input: 했는데, 웃고, 밤, 모여서
+output: 하다, 웃다, 밤, 모이다
 \`\`\`
 `,
 };
@@ -185,5 +237,68 @@ export class TranslateService {
     this.logger.verbose(sentence);
 
     return sentence;
+  }
+
+  async genLearningSet(words: string[]): Promise<Map<string, LearningSet>> {
+    const model = new ChatGoogleGenerativeAI({
+      model: 'gemini-1.5-flash',
+      maxOutputTokens: 2048,
+      safetySettings: GlobalSafetySettings,
+    });
+
+    const preds = new Map<string, LearningSet>();
+
+    for await (const word of words) {
+      this.logger.debug(`Generating learning set for ${word}...`);
+      const pred = await model.invoke([
+        ['system', SystemPrompts.learningSet],
+        ['user', word],
+      ]);
+
+      // remove markdown code block
+      const parsed = parse(
+        pred.content.toString().replaceAll('```yaml', '').replaceAll('```', '')
+      );
+
+      // type check for parsed
+      const isVaild = this.isVaildLearningSet(parsed);
+      if (!isVaild) {
+        this.logger.error(`Invalid learning set: ${word}`);
+        console.dir(parsed);
+        continue;
+      }
+
+      preds.set(word, parsed as LearningSet);
+    }
+
+    return preds;
+  }
+
+  isVaildLearningSet(parsed: any): boolean {
+    let isVaild = typeof parsed === 'object';
+
+    isVaild =
+      isVaild &&
+      parsed.hasOwnProperty('translation') &&
+      typeof parsed.translation === 'string';
+
+    // 유의어, 반의어, 주의사항은 없을 수 있음을 감안하여 상세 타입 체크 제외
+    isVaild = isVaild && parsed.hasOwnProperty('synonyms');
+
+    isVaild = isVaild && parsed.hasOwnProperty('antonyms');
+
+    isVaild = isVaild && parsed.hasOwnProperty('caution');
+
+    isVaild =
+      isVaild &&
+      parsed.hasOwnProperty('pronunciation') &&
+      typeof parsed.pronunciation === 'string';
+
+    isVaild =
+      isVaild &&
+      parsed.hasOwnProperty('exercises') &&
+      Array.isArray(parsed.exercises);
+
+    return isVaild;
   }
 }

--- a/main-server/src/modules/translate/translate.service.ts
+++ b/main-server/src/modules/translate/translate.service.ts
@@ -301,4 +301,25 @@ export class TranslateService {
 
     return isVaild;
   }
+
+  // 주어진 단어에 대해 순서대로 기본형으로 변환합니다.
+  async getPrincipalParts(words: string[]): Promise<string[]> {
+    const model = new ChatGoogleGenerativeAI({
+      model: 'gemini-1.5-flash',
+      maxOutputTokens: 2048,
+      safetySettings: GlobalSafetySettings,
+    });
+
+    const pred = await model.invoke([
+      ['system', SystemPrompts.PrincipalParts],
+      ['user', '참았던, 심심한, 모른'],
+      ['assistant', '참다, 심심하다, 모르다'],
+      ['user', words.join(', ')],
+    ]);
+
+    return pred.content
+      .toString()
+      .split(', ')
+      .map((v) => v.trim().replaceAll('\n', ''));
+  }
 }


### PR DESCRIPTION
* 기본형 변환 함수 추가: `getPrincipalParts()`
* 학습자료 생성 함수 추가: `genLearningSet()`
* 학습자료 타입 추가: `LearningSet`
* 학습자료 타입 검증 함수 추가: `isVaildLearningSet()`
* Mocking 환경 변수에  `KOREAN_ANALYZE_API_KEY`가 없어 트랜스파일 안되는 오류 수정
* `/translate/test` Endpoint에 한해 JWT 토큰 검증 비활성화 (함수 테스트 용)